### PR TITLE
remove unused #[macro_use]

### DIFF
--- a/ahcid/src/main.rs
+++ b/ahcid/src/main.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 #![feature(asm)]
 
-#[macro_use]
 extern crate bitflags;
 extern crate spin;
 extern crate syscall;


### PR DESCRIPTION
Otherwise, compilation fails with:

```
error: unused `#[macro_use]` import
 --> drivers/ahcid/src/main.rs:4:1
  |
4 | #[macro_use]
  | ^^^^^^^^^^^^
  |
note: lint level defined here
 --> drivers/ahcid/src/main.rs:1:9
  |
1 | #![deny(warnings)]
  |         ^^^^^^^^

error: aborting due to previous error

error: Could not compile `ahcid`.
```