### PR TITLE
Fix missing use statement

### DIFF
--- a/ahcid/src/ahci/hba.rs
+++ b/ahcid/src/ahci/hba.rs
@@ -1,6 +1,7 @@
 use std::mem::size_of;
 use std::ops::DerefMut;
 use std::{ptr, u32};
+use std::thread;
 
 use syscall::io::{Dma, Io, Mmio};
 use syscall::error::{Error, Result, EIO};

--- a/ahcid/src/ahci/hba.rs
+++ b/ahcid/src/ahci/hba.rs
@@ -1,7 +1,6 @@
 use std::mem::size_of;
 use std::ops::DerefMut;
-use std::{ptr, u32};
-use std::thread;
+use std::{ptr, u32, thread};
 
 use syscall::io::{Dma, Io, Mmio};
 use syscall::error::{Error, Result, EIO};


### PR DESCRIPTION
Fixed missing use std::thread, as noted in issue [redox#883](https://github.com/redox-os/redox/issues/883) This should fix redox compilation at this moment.