### PR TITLE
ihdad: Fix seek flags

### DIFF
--- a/ihdad/src/HDA/device.rs
+++ b/ihdad/src/HDA/device.rs
@@ -16,7 +16,8 @@ extern crate syscall;
 
 use syscall::MAP_WRITE;
 use syscall::error::{Error, EACCES, EBADF, Result, EINVAL};
-use syscall::io::{ Mmio, Io};
+use syscall::flag::{SEEK_SET, SEEK_CUR, SEEK_END};
+use syscall::io::{Mmio, Io};
 use syscall::scheme::SchemeMut;
 
 use spin::Mutex;


### PR DESCRIPTION
This pull request fixes some missing imports in `ihdad`. Those missing imports made a match statement to treat its branches as variable bindings instead of constants.

[Affected code](https://github.com/redox-os/drivers/blob/402b46561b3f5e4351ab45c599cee8acfb2c2b39/ihdad/src/HDA/device.rs#L1013-L1018), [Fixed warnings](https://gist.github.com/xTibor/8ef3fb38910f86c29fdd9508e67e8030)