### PR TITLE
Allow using a device ID range in toml config

### DIFF
--- a/pcid/src/config.rs
+++ b/pcid/src/config.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
     pub drivers: Vec<DriverConfig>
@@ -11,5 +13,6 @@ pub struct DriverConfig {
     pub interface: Option<u8>,
     pub vendor: Option<u16>,
     pub device: Option<u16>,
+    pub device_id_range: Option<Range<u16>>,
     pub command: Option<Vec<String>>
 }

--- a/pcid/src/main.rs
+++ b/pcid/src/main.rs
@@ -115,6 +115,11 @@ fn main() {
                             if device != header.device_id { continue; }
                         }
 
+                        if let Some(ref device_id_range) = driver.device_id_range {
+                            if header.device_id < device_id_range.start  ||
+                               device_id_range.end <= header.device_id { continue; }
+                        }
+
                         if let Some(ref args) = driver.command {
                             // Enable bus mastering, memory space, and I/O space
                             unsafe {
@@ -149,6 +154,7 @@ fn main() {
                                             "$IRQ" => format!("{}", header.interrupt_line),
                                             "$VENID" => format!("{:>04X}",header.vendor_id),
                                             "$DEVID" => format!("{:>04X}",header.device_id),
+                                            "$SUBSYSID" => format!("{:>04X}",header.subsystem_id),
                                             _ => arg.clone()
                                         }
                                     };


### PR DESCRIPTION
Allow toml like the following

```
# virtio
[[drivers]]
name = "VIRTIO"
vendor = 6900
device_id_range = { start = 4096, end = 4160 }
command = ["virtiod", "$NAME", "$BAR0", "$BAR1",
           "$IRQ", "$DEVID", "$SUBSYSID"]
```