### PR TITLE
vesad: Fix Unicode character input

### DIFF
--- a/vesad/src/screen/text.rs
+++ b/vesad/src/screen/text.rs
@@ -105,7 +105,8 @@ impl Screen for TextScreen {
                             };
 
                             if c != '\0' {
-                                buf.extend_from_slice(&[c as u8]);
+                                let mut b = [0; 4];
+                                buf.extend_from_slice(c.encode_utf8(&mut b).as_bytes());
                             }
                         }
                     }


### PR DESCRIPTION
Characters beyond 0x80 now properly encoded as UTF-8.