### PR TITLE
register write bug fixes

### DIFF
--- a/net/ixgbed/src/device.rs
+++ b/net/ixgbed/src/device.rs
@@ -290,7 +290,7 @@ impl Intel8259x {
         self.wait_write_reg(IXGBE_EEC, IXGBE_EEC_ARD);
 
         // section 4.6.3 - wait for dma initialization done
-        self.wait_write_reg(IXGBE_RDRXCTL, IXGBE_RDRXCTL_DMAIDONE);
+        self.wait_write_reg(IXGBE_RDRXCTL, IXGBE_RDRXCTL_DMAIDONE | IXGBE_RDRXCTL_RESERVED_BITS);
 
         // section 4.6.4 - initialize link (auto negotiation)
         self.init_link();
@@ -397,7 +397,7 @@ impl Intel8259x {
         }
 
         // required when not using DCB/VTd
-        self.write_reg(IXGBE_DTXMXSZRQ, 0xffff);
+        self.write_reg(IXGBE_DTXMXSZRQ, 0xfff);
         self.clear_flag(IXGBE_RTTDCS, IXGBE_RTTDCS_ARBDIS);
 
         // configure a single transmit queue/ring
@@ -508,11 +508,15 @@ impl Intel8259x {
 
     /// Enables or disables promisc mode of this device.
     fn set_promisc(&self, enabled: bool) {
+        self.clear_flag(IXGBE_RXCTRL, IXGBE_RXCTRL_RXEN);
+
         if enabled {
             self.write_flag(IXGBE_FCTRL, IXGBE_FCTRL_MPE | IXGBE_FCTRL_UPE);
         } else {
             self.clear_flag(IXGBE_FCTRL, IXGBE_FCTRL_MPE | IXGBE_FCTRL_UPE);
         }
+    
+        self.write_flag(IXGBE_RXCTRL, IXGBE_RXCTRL_RXEN);
     }
 
     /// Set the IVAR registers, mapping interrupt causes to vectors.

--- a/net/ixgbed/src/ixgbe.rs
+++ b/net/ixgbed/src/ixgbe.rs
@@ -14,6 +14,7 @@ pub const IXGBE_EEC: u32                        = 0x10010;
 pub const IXGBE_EEC_ARD: u32                    = 0x00000200; /* EEPROM Auto Read Done */
 
 pub const IXGBE_RDRXCTL: u32                    = 0x02F00;
+pub const IXGBE_RDRXCTL_RESERVED_BITS: u32      = 1 << 25 | 1 << 26;
 pub const IXGBE_RDRXCTL_DMAIDONE: u32           = 0x00000008; /* DMA init cycle done */
 
 pub const IXGBE_AUTOC: u32                      = 0x042A0;


### PR DESCRIPTION
Fixes to the following bugs in the ixgbe driver:

- Write to reserved bits [15:12] of the DTXMXSZRQ register
- Bits of RDRXCTL are not set by software. According to the datasheet:
         RDRXCTL.RSCACKC (bit 25) is by default 0 and should be set to 1 by software.
         RDRXCTL.FCOE_WRFIX (bit 26) is by default 0 and should be set to 1 by software.
- The FCTRL register (receive filters) should only be modified/ updated when the RXCTRL.RXEN bit is set to 0, after which it should be re-enabled. The set_promisc function updates the filters after RXCTRL.RXEN is set.
